### PR TITLE
Fix #137: Prevent 'After' from being detected as feet/foot

### DIFF
--- a/conversion/src/main/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverter.java
+++ b/conversion/src/main/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The social-metricbot contributors
+ * Copyright 2020-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public class FootInchConverter implements io.github.bmarwell.social.metricbot.co
      * 2nd matcher is using foot|feet|ft find numbers.
      */
     private static final Pattern FOOT_OR_FEET_TEXT = Pattern.compile(
-            "\\b([0-9]+,[0-9]{3,}|[0-9]{0,2}|a)\\s*(foot|feet|ft)\\s*(([0-9]{0,2}(\\.[0-9]{0,2})?)(\")?|\\b)",
+            "\\b([0-9]+,[0-9]{3,}|[0-9]{1,2}|a)\\s*(foot|feet|ft)\\b\\s*(([0-9]{0,2}(\\.[0-9]{0,2})?)(\")?|\\b)",
             Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     /**
@@ -59,7 +59,8 @@ public class FootInchConverter implements io.github.bmarwell.social.metricbot.co
      * 4th matcher for literal foot/feet only.
      */
     private static final Pattern FT_TEXT = Pattern.compile(
-            "\\b(?<num>\\d+(,\\d+)?|\\d{0,2}|a)\\s*(?:foot|feet|ft)", Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
+            "\\b(?<num>[0-9]+(?:,[0-9]{3,})?|[0-9]{1,2}|a)\\s*(?:foot|feet|ft)\\b",
+            Pattern.MULTILINE | Pattern.CASE_INSENSITIVE);
 
     private static final NumberFormat numberFormatCm = DecimalFormats.atMostOneFractionDigits();
     private static final NumberFormat numberFormatFt = DecimalFormats.atMostTwoFractionDigits();

--- a/conversion/src/test/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverterTest.java
+++ b/conversion/src/test/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 The social-metricbot contributors
+ * Copyright 2020-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,7 @@ public class FootInchConverterTest {
     @Test
     public void testBogusInputMatches() {
         // given
-        final String tweet =
-                """
+        final String tweet = """
                 Here's the recipe:
 
                 2 cups of Pancake Mix
@@ -57,8 +56,7 @@ public class FootInchConverterTest {
     @Test
     public void testBogusInputDoesNotConvert() {
         // given
-        final String tweet =
-                """
+        final String tweet = """
                 Here's the recipe:
 
                 2 cups of Pancake Mix
@@ -86,8 +84,7 @@ public class FootInchConverterTest {
     @Test
     void this_produces_nfe() {
         // given
-        final var input =
-                """
+        final var input = """
             1mi but 1,500 hp.
             12 inches in a foot.
             2 cups water.
@@ -101,5 +98,47 @@ public class FootInchConverterTest {
 
         // then
         Assertions.assertThat(matches).hasSize(3);
+    }
+
+    @Test
+    void testAfterShouldNotMatchFeet() {
+        // given - issue #137
+        final var input =
+                "I'll take 100 gallons. After last month's power bill, I need to coat my entire house in this!";
+        final var footInchConverter = new FootInchConverter();
+
+        // when
+        final boolean matches = footInchConverter.matches(input);
+
+        // then
+        assertFalse(matches, "The word 'After' should not match as feet/foot");
+    }
+
+    @Test
+    void testAfterShouldNotConvert() {
+        // given - issue #137
+        final var input =
+                "I'll take 100 gallons. After last month's power bill, I need to coat my entire house in this!";
+        final var footInchConverter = new FootInchConverter();
+
+        // when
+        final Collection<UnitConversion> conversions = footInchConverter.getConvertedUnits(input);
+
+        // then
+        assertTrue(conversions.isEmpty(), "The word 'After' should not produce any conversions");
+    }
+
+    @Test
+    void testValidFeetFormats() {
+        // given - ensure these still work
+        final var footInchConverter = new FootInchConverter();
+
+        // when/then
+        assertTrue(footInchConverter.matches("10ft"), "10ft should match");
+        assertTrue(footInchConverter.matches("10 ft"), "10 ft should match");
+        assertTrue(footInchConverter.matches("10 feet"), "10 feet should match");
+        assertTrue(footInchConverter.matches("10 foot"), "10 foot should match");
+        assertTrue(footInchConverter.matches("5'6\""), "5'6\" should match");
+        assertTrue(footInchConverter.matches("a foot"), "a foot should match");
     }
 }

--- a/conversion/src/test/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverterTest.java
+++ b/conversion/src/test/java/io/github/bmarwell/social/metricbot/conversion/converters/FootInchConverterTest.java
@@ -141,4 +141,32 @@ public class FootInchConverterTest {
         assertTrue(footInchConverter.matches("5'6\""), "5'6\" should match");
         assertTrue(footInchConverter.matches("a foot"), "a foot should match");
     }
+
+    @Test
+    void testUnitWordsAloneShouldNotMatch() {
+        // given - these would have matched with the old pattern and hit the feet.isEmpty() check
+        final var footInchConverter = new FootInchConverter();
+
+        // when/then - unit words without numbers should not match
+        assertFalse(footInchConverter.matches("ft alone"), "bare 'ft' should not match");
+        assertFalse(footInchConverter.matches("feet alone"), "bare 'feet' should not match");
+        assertFalse(footInchConverter.matches("foot alone"), "bare 'foot' should not match");
+        assertFalse(footInchConverter.matches("the ft is"), "bare 'ft' in sentence should not match");
+    }
+
+    @Test
+    void testUnitWordsAloneShouldNotConvert() {
+        // given - ensure no conversions happen for bare unit words
+        final var footInchConverter = new FootInchConverter();
+
+        // when/then
+        assertTrue(
+                footInchConverter.getConvertedUnits("ft alone").isEmpty(), "bare 'ft' should not produce conversions");
+        assertTrue(
+                footInchConverter.getConvertedUnits("feet alone").isEmpty(),
+                "bare 'feet' should not produce conversions");
+        assertTrue(
+                footInchConverter.getConvertedUnits("foot alone").isEmpty(),
+                "bare 'foot' should not produce conversions");
+    }
 }


### PR DESCRIPTION
- Changed FOOT_OR_FEET_TEXT pattern from [0-9]{0,2} to [0-9]{1,2}
- Changed FT_TEXT pattern from \d{0,2} to [0-9]{1,2}
- Added word boundary \b after (foot|feet|ft) to prevent matching
  partial words like 'Aft' in 'After'
- Added unit tests to verify 'After' is not matched
- Added tests to verify valid formats still work: 10ft, 10 ft, etc.
