### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,19 +2,21 @@ name: CodeQL
 
 on:
   workflow_dispatch: { }
-  push: { }
+  push:
+    branches: [main]
   pull_request: { }
   schedule:
     - cron: '0 6 * * 1'
 
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
 jobs:
   analyze:
-    if: github.ref_name == 'main' || github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [ 'ubuntu-latest' ]
     steps:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,7 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         languages: java
+        build-mode: manual
         config-file: .github/codeql/codeql-config.yml
 
     - name: Build with Maven

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+on:
+  workflow_dispatch: { }
+  push: { }
+  pull_request: { }
+  schedule:
+    - cron: '0 6 * * 1'
+
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    if: github.ref_name == 'main' || github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: [ 'ubuntu-latest' ]
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v6.0.2
+      with:
+        show-progress: false
+
+    - name: Set up JDK
+      uses: actions/setup-java@v5.2.0
+      with:
+        java-version: 25
+        distribution: semeru
+        cache: 'maven'
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: java
+        config-file: .github/codeql/codeql-config.yml
+
+    - name: Build with Maven
+      shell: bash
+      run: >
+        ./mvnw
+        --show-version
+        --errors
+        --batch-mode
+        --no-transfer-progress
+        compile
+        -DtrimStackTrace=false
+        -Dspotless.skip=true
+        -Dmaven.build.cache.enabled=false
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: '/language:java'


### PR DESCRIPTION
## Summary

Adds GitHub CodeQL security analysis for the Java 25 codebase.

### Changes
- `.github/codeql/codeql-config.yml` — CodeQL config using `security-extended` query suite
- `.github/workflows/codeql.yml` — CodeQL workflow following project conventions

### Workflow behaviour
- Runs on **push to `main`**, **PRs from same repo**, **weekly schedule** (Mondays 06:00 UTC), and **manual dispatch**
- Uses `actions/setup-java@v5.2.0` with Java 25 / Semeru and Maven cache (consistent with other workflows)
- Builds via `./mvnw compile` so CodeQL can trace the build
- Uploads SARIF results to the Security tab via `github/codeql-action/analyze@v3`