### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   mutationtesting:
     runs-on: [ 'ubuntu-latest' ]


### PR DESCRIPTION
Potential fix for [https://github.com/bmarwell/social-metricbot/security/code-scanning/1](https://github.com/bmarwell/social-metricbot/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: add `permissions: contents: read` at the workflow root (after `on:` and before `jobs:`), since all shown steps only require repository read access (`actions/checkout`, Maven test run). This avoids changing behavior while preventing implicit broader token rights.

File to change:
- `.github/workflows/mutation-testing.yml`
  - Insert a root-level permissions block between the trigger section and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
