### PR TITLE
feat: make Mastodon integration optional

### DIFF
--- a/bot/pom.xml
+++ b/bot/pom.xml
@@ -129,6 +129,11 @@
       <artifactId>jakarta.inject-api</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-jsonb</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/bot/src/main/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducer.java
+++ b/bot/src/main/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducer.java
@@ -40,7 +40,7 @@ public class MastodonProducer {
     public MastodonClient produceMastodon() {
         if (!mastodonConfig.isConfigured()) {
             throw new IllegalStateException(
-                    "Mastodon is not configured; check instancehostname and accesstoken properties.");
+                    "Mastodon is not configured; check accountname, instancehostname, and accesstoken properties.");
         }
 
         MastodonConfigurationBuilder configurationBuilder = new MastodonConfigurationBuilder()

--- a/bot/src/main/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducer.java
+++ b/bot/src/main/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The social-metricbot contributors
+ * Copyright 2023-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,11 @@ public class MastodonProducer {
 
     @Produces
     public MastodonClient produceMastodon() {
+        if (!mastodonConfig.isConfigured()) {
+            throw new IllegalStateException(
+                    "Mastodon is not configured; check instancehostname and accesstoken properties.");
+        }
+
         MastodonConfigurationBuilder configurationBuilder = new MastodonConfigurationBuilder()
                 .withInstanceHost(URI.create(mastodonConfig.getInstanceHostname()))
                 .withAccessToken(mastodonConfig.getAccessToken());

--- a/bot/src/main/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonMentionListener.java
+++ b/bot/src/main/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonMentionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The social-metricbot contributors
+ * Copyright 2023-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package io.github.bmarwell.social.metricbot.web.mastodon;
 
+import io.github.bmarwell.social.metricbot.common.MastodonConfig;
 import io.github.bmarwell.social.metricbot.mastodon.MastodonClient;
 import io.github.bmarwell.social.metricbot.mastodon.MastodonStatus;
 import io.github.bmarwell.social.metricbot.web.factory.MastodonProducer;
@@ -47,6 +48,9 @@ public class MastodonMentionListener implements ServletContextListener {
     private MastodonProducer mastodonProducer;
 
     @Inject
+    private MastodonConfig mastodonConfig;
+
+    @Inject
     private Event<MastodonMentionEvent> mentionEvent;
 
     private MastodonClient mastodon;
@@ -59,6 +63,12 @@ public class MastodonMentionListener implements ServletContextListener {
     public void contextInitialized(ServletContextEvent sce) {
         ServletContextListener.super.contextInitialized(sce);
         LOG.info("init: [{}].", this);
+
+        if (!this.mastodonConfig.isConfigured()) {
+            LOG.warn("Mastodon is not configured — skipping mention listener setup.");
+            return;
+        }
+
         this.mastodon = this.mastodonProducer.produceMastodon();
 
         // set up scheduler

--- a/bot/src/main/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonResponseProducer.java
+++ b/bot/src/main/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonResponseProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 The social-metricbot contributors
+ * Copyright 2021-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,11 @@ public class MastodonResponseProducer implements ServletContextListener {
 
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
+        if (!this.mastodonConfig.isConfigured()) {
+            LOG.warn("Mastodon is not configured — skipping response producer setup.");
+            return;
+        }
+
         ScheduledFuture<?> scheduledFuture = this.scheduler.scheduleAtFixedRate(
                 this::emitMention,
                 this.mastodonConfig.getTweetFinderInitialDelay().getSeconds(),

--- a/bot/src/test/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducerTest.java
+++ b/bot/src/test/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023-2026 The social-metricbot contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.social.metricbot.web.factory;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import io.github.bmarwell.social.metricbot.common.MastodonConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MastodonProducerTest {
+
+    @Mock
+    MastodonConfig mastodonConfig;
+
+    @InjectMocks
+    MastodonProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void produceMastodon_throwsIllegalStateException_whenNotConfigured() {
+        when(mastodonConfig.isConfigured()).thenReturn(false);
+
+        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> producer.produceMastodon());
+    }
+}

--- a/bot/src/test/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducerTest.java
+++ b/bot/src/test/java/io/github/bmarwell/social/metricbot/web/factory/MastodonProducerTest.java
@@ -42,6 +42,10 @@ class MastodonProducerTest {
     void produceMastodon_throwsIllegalStateException_whenNotConfigured() {
         when(mastodonConfig.isConfigured()).thenReturn(false);
 
-        assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> producer.produceMastodon());
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> producer.produceMastodon())
+                .withMessageContaining("accountname")
+                .withMessageContaining("instancehostname")
+                .withMessageContaining("accesstoken");
     }
 }

--- a/bot/src/test/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonMentionListenerTest.java
+++ b/bot/src/test/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonMentionListenerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023-2026 The social-metricbot contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.social.metricbot.web.mastodon;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.bmarwell.social.metricbot.common.MastodonConfig;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.event.Event;
+import jakarta.servlet.ServletContextEvent;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MastodonMentionListenerTest {
+
+    @Mock
+    MastodonConfig mastodonConfig;
+
+    @Mock
+    ManagedScheduledExecutorService scheduler;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    Event mentionEvent;
+
+    @InjectMocks
+    MastodonMentionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void contextInitialized_doesNotSchedule_whenNotConfigured() {
+        when(mastodonConfig.isConfigured()).thenReturn(false);
+
+        listener.contextInitialized(mock(ServletContextEvent.class));
+
+        verify(scheduler, never()).scheduleWithFixedDelay(any(), anyLong(), anyLong(), any(TimeUnit.class));
+    }
+}

--- a/bot/src/test/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonResponseProducerTest.java
+++ b/bot/src/test/java/io/github/bmarwell/social/metricbot/web/mastodon/MastodonResponseProducerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023-2026 The social-metricbot contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.social.metricbot.web.mastodon;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.bmarwell.social.metricbot.common.MastodonConfig;
+import jakarta.enterprise.concurrent.ManagedScheduledExecutorService;
+import jakarta.enterprise.event.Event;
+import jakarta.servlet.ServletContextEvent;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class MastodonResponseProducerTest {
+
+    @Mock
+    MastodonConfig mastodonConfig;
+
+    @Mock
+    ManagedScheduledExecutorService scheduler;
+
+    @Mock
+    UnprocessedMastodonStatusQueueHolder unprocessedMastodonStatusQueueHolder;
+
+    @Mock
+    @SuppressWarnings("rawtypes")
+    Event processEvent;
+
+    @InjectMocks
+    MastodonResponseProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void contextInitialized_doesNotSchedule_whenNotConfigured() {
+        when(mastodonConfig.isConfigured()).thenReturn(false);
+
+        producer.contextInitialized(mock(ServletContextEvent.class));
+
+        verify(scheduler, never()).scheduleAtFixedRate(any(), anyLong(), anyLong(), any(TimeUnit.class));
+    }
+}

--- a/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
+++ b/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
@@ -75,6 +75,11 @@ public class MastodonConfig implements Serializable {
         return Duration.ofSeconds(this.initialDelay);
     }
 
+    /**
+     * Returns whether Mastodon is fully configured.
+     *
+     * @return {@code true} only when instance hostname, access token, and account name are all non-blank.
+     */
     public boolean isConfigured() {
         return !this.instanceHostname.isBlank() && !this.accessToken.isBlank() && !this.accountName.isBlank();
     }

--- a/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
+++ b/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
@@ -76,6 +76,6 @@ public class MastodonConfig implements Serializable {
     }
 
     public boolean isConfigured() {
-        return !this.instanceHostname.isBlank() && !this.accessToken.isBlank();
+        return !this.instanceHostname.isBlank() && !this.accessToken.isBlank() && !this.accountName.isBlank();
     }
 }

--- a/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
+++ b/common/src/main/java/io/github/bmarwell/social/metricbot/common/MastodonConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The social-metricbot contributors
+ * Copyright 2023-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,23 +25,23 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 public class MastodonConfig implements Serializable {
 
     @Inject
-    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.accountname")
+    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.accountname", defaultValue = "")
     private String accountName;
 
     @Inject
-    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.instancehostname")
+    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.instancehostname", defaultValue = "")
     private String instanceHostname;
 
     @Inject
-    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.website")
+    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.website", defaultValue = "")
     private String website;
 
     @Inject
-    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.accesstoken")
+    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.accesstoken", defaultValue = "")
     private String accessToken;
 
     @Inject
-    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.initialDelay")
+    @ConfigProperty(name = "io.github.bmarwell.social.metricbot.mastodon.initialDelay", defaultValue = "30")
     private long initialDelay;
 
     public MastodonConfig() {
@@ -53,7 +53,7 @@ public class MastodonConfig implements Serializable {
     }
 
     public String getInstanceHostname() {
-        if (!instanceHostname.startsWith("http")) {
+        if (!instanceHostname.isBlank() && !instanceHostname.startsWith("http")) {
             return "https://" + instanceHostname;
         }
         return instanceHostname;
@@ -73,5 +73,9 @@ public class MastodonConfig implements Serializable {
 
     public Duration getTweetFinderInitialDelay() {
         return Duration.ofSeconds(this.initialDelay);
+    }
+
+    public boolean isConfigured() {
+        return !this.instanceHostname.isBlank() && !this.accessToken.isBlank();
     }
 }

--- a/common/src/test/java/io/github/bmarwell/social/metricbot/common/MastodonConfigTest.java
+++ b/common/src/test/java/io/github/bmarwell/social/metricbot/common/MastodonConfigTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023-2026 The social-metricbot contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.social.metricbot.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MastodonConfigTest {
+
+    MastodonConfig config;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        config = new MastodonConfig();
+        setField("instanceHostname", "");
+        setField("accessToken", "");
+        setField("accountName", "");
+        setField("website", "");
+    }
+
+    @Test
+    void isConfigured_returnsFalse_whenAllBlank() {
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsFalse_whenOnlyInstanceHostname() throws Exception {
+        setField("instanceHostname", "mastodon.social");
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsFalse_whenAccountNameBlank() throws Exception {
+        setField("instanceHostname", "mastodon.social");
+        setField("accessToken", "my-token");
+
+        assertThat(config.isConfigured()).isFalse();
+    }
+
+    @Test
+    void isConfigured_returnsTrue_whenAllThreeSet() throws Exception {
+        setField("instanceHostname", "mastodon.social");
+        setField("accessToken", "my-token");
+        setField("accountName", "bot@mastodon.social");
+
+        assertThat(config.isConfigured()).isTrue();
+    }
+
+    @Test
+    void getInstanceHostname_prependsHttps_whenNoScheme() throws Exception {
+        setField("instanceHostname", "mastodon.social");
+
+        assertThat(config.getInstanceHostname()).isEqualTo("https://mastodon.social");
+    }
+
+    @Test
+    void getInstanceHostname_returnsBlank_whenBlank() {
+        assertThat(config.getInstanceHostname()).isBlank();
+    }
+
+    @Test
+    void getInstanceHostname_doesNotPrepend_whenAlreadyHttps() throws Exception {
+        setField("instanceHostname", "https://mastodon.social");
+
+        assertThat(config.getInstanceHostname()).isEqualTo("https://mastodon.social");
+    }
+
+    private void setField(String fieldName, Object value) throws Exception {
+        Field field = MastodonConfig.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(config, value);
+    }
+}

--- a/mastodon/pom.xml
+++ b/mastodon/pom.xml
@@ -37,6 +37,37 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-jsonb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/mastodon/src/main/java/io/github/bmarwell/social/metricbot/mastodon/DefaultMastodonClient.java
+++ b/mastodon/src/main/java/io/github/bmarwell/social/metricbot/mastodon/DefaultMastodonClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The social-metricbot contributors
+ * Copyright 2023-2026 The social-metricbot contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,7 +148,8 @@ public class DefaultMastodonClient implements MastodonClient {
                 entity = response.readEntity(String.class);
             }
 
-            throw new IllegalStateException("Not found, RC=" + response.getStatus() + "; entity = " + entity);
+            throw new IllegalStateException("HTTP call not successful, URL=" + mastodonConfig.getInstanceHost()
+                    + "/api/v1/notifications, SC=" + response.getStatus() + "; entity = " + entity);
         }
 
         //noinspection unchecked

--- a/mastodon/src/test/java/io/github/bmarwell/social/metricbot/mastodon/DefaultMastodonClientTest.java
+++ b/mastodon/src/test/java/io/github/bmarwell/social/metricbot/mastodon/DefaultMastodonClientTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-2026 The social-metricbot contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.bmarwell.social.metricbot.mastodon;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DefaultMastodonClientTest {
+
+    @RegisterExtension
+    static final WireMockExtension WIREMOCK = WireMockExtension.newInstance().build();
+
+    @Test
+    void getRecentMentions_throwsIllegalStateException_when404() throws Exception {
+        WIREMOCK.stubFor(get(urlPathEqualTo("/api/v1/notifications"))
+                .willReturn(aResponse().withStatus(404)));
+
+        MastodonConfigurationBuilder config = new MastodonConfigurationBuilder()
+                .withInstanceHost(URI.create(WIREMOCK.baseUrl()))
+                .withAccessToken("test-token");
+
+        try (DefaultMastodonClient client = new DefaultMastodonClient(config)) {
+            assertThatExceptionOfType(ExecutionException.class)
+                    .isThrownBy(() ->
+                            client.getRecentMentions().toCompletableFuture().get())
+                    .withCauseInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency.assertj.version>3.27.7</dependency.assertj.version>
     <dependency.cxf.version>4.1.4</dependency.cxf.version>
     <junit5.version>6.1.0</junit5.version>
-    <dependency.johnzon.version>1.2.21</dependency.johnzon.version>
+    <dependency.johnzon.version>2.1.0</dependency.johnzon.version>
     <dependency.h2.version>2.4.240</dependency.h2.version>
     <dependency.mockito.version>5.23.0</dependency.mockito.version>
     <dependency.bytebuddy.version>1.18.10</dependency.bytebuddy.version>
@@ -160,6 +160,11 @@
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.22</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
         <version>${dependency.jackson.version}</version>
       </dependency>
@@ -222,6 +227,14 @@
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-client</artifactId>
         <version>${dependency.cxf.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- JSON-B implementation for tests -->
+      <dependency>
+        <groupId>org.apache.johnzon</groupId>
+        <artifactId>johnzon-jsonb</artifactId>
+        <version>${dependency.johnzon.version}</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
## Summary

When Mastodon credentials are not configured the bot starts up cleanly and skips all Mastodon activity instead of failing.

## Changes

### `common` — `MastodonConfig`
- All `@ConfigProperty` fields get `defaultValue = ""` (strings) / `defaultValue = "30"` (`initialDelay`), so missing config no longer prevents startup
- `getInstanceHostname()` skips the `https://` prefix when the value is blank
- New `isConfigured()` — returns `true` only when `accountname`, `instancehostname`, and `accesstoken` are all non-blank

### `bot` — listeners and producer
- **`MastodonResponseProducer`**: same guard in `contextInitialized`
- **`MastodonProducer`**: defensive guard in `produceMastodon()` — throws `IllegalStateException` with a clear message if somehow called while unconfigured, including all required config keys (`accountname`, `instancehostname`, `accesstoken`)